### PR TITLE
Move makefile to python

### DIFF
--- a/barcode-gen.py
+++ b/barcode-gen.py
@@ -2,6 +2,7 @@
 import time
 import argparse
 import re
+import subprocess
 
 import code128
 
@@ -36,9 +37,14 @@ style="fill:black;font-size:16pt;text-anchor:middle;"
 </g>
 </svg>"""
 for (dashed_code, code) in zip(dashed_codes, codes):
-    out_file = code+".svg"
+    svg_file = code+'.svg'
+    png_file = code+'.png'
     svg = code128.svg(code)
 
-    with open(out_file,'w') as o:
+    # Generate the svg
+    with open(svg_file,'w') as file:
         svg_content = "\n".join(svg.split("\n")[3:-2])
-        print(template.format(bar=svg_content,code=dashed_code),file=o)
+        print(template.format(bar=svg_content,code=dashed_code),file=file)
+
+    # Convert to png
+    subprocess.check_call(['inkscape', svg_file, '--export-png='+png_file, '--export-width=991', '--export-height=306']);

--- a/barcode-gen.py
+++ b/barcode-gen.py
@@ -2,6 +2,7 @@
 import time
 import argparse
 import re
+import os
 import subprocess
 
 import code128
@@ -37,6 +38,7 @@ style="fill:black;font-size:16pt;text-anchor:middle;"
 </g>
 </svg>"""
 for (dashed_code, code) in zip(dashed_codes, codes):
+    print("Generating code:",dashed_code)
     svg_file = code+'.svg'
     png_file = code+'.png'
     svg = code128.svg(code)
@@ -47,4 +49,7 @@ for (dashed_code, code) in zip(dashed_codes, codes):
         print(template.format(bar=svg_content,code=dashed_code),file=file)
 
     # Convert to png
-    subprocess.check_call(['inkscape', svg_file, '--export-png='+png_file, '--export-width=991', '--export-height=306']);
+    command = ['inkscape', svg_file, '--export-png='+png_file, '--export-width=991', '--export-height=306']
+    err = subprocess.check_call(command,stdout=open(os.devnull,'w'),stderr=subprocess.STDOUT);
+    if err != 0:
+        raise Exception("Inkscape returned non-zero error code, command was:",command)

--- a/makefile
+++ b/makefile
@@ -8,13 +8,10 @@ all: clean build
 clean:
 	rm -rf *.svg *.png
 
-build:
+build: clean
 	python barcode-gen.py `cat codes`
-	for i in *.svg; do\
-	 inkscape $$i --export-png "$${i%.*}.png" --export-width=991 --export-height=306;\
-	done
 
-print:
+print: build
 	# Print using a brother QL-570 on the 29x90.3mm labels
 	for i in *.png; do\
          brother_ql_create --model $(printer_model) --label-size=$(label_size) "$$i" > /dev/usb/lp1;\


### PR DESCRIPTION
Move the conversion of svg to the makefile, so the python script can be run directly without make and still produce useful output.